### PR TITLE
An easy way to save your theming into MX Tweak Theme Files

### DIFF
--- a/tweak/defaultlook.cpp
+++ b/tweak/defaultlook.cpp
@@ -1793,7 +1793,7 @@ QString defaultlook::getVersion(QString name)
     return runCmd("dpkg-query -f '${Version}' -W " + name).output;
 }
 
-void defaultlook::on_pushButton_clicked()
+void defaultlook::on_pushButtonSettingsToThemeSet_clicked()
 {
     QString fileName;
     theming_to_tweak* dialog = new theming_to_tweak;

--- a/tweak/defaultlook.h
+++ b/tweak/defaultlook.h
@@ -179,6 +179,8 @@ private slots:
 
     void on_checkboxRadeontearfree_clicked();
 
+    void on_pushButton_clicked();
+
 private:
     Ui::defaultlook *ui;
 };

--- a/tweak/defaultlook.h
+++ b/tweak/defaultlook.h
@@ -179,7 +179,7 @@ private slots:
 
     void on_checkboxRadeontearfree_clicked();
 
-    void on_pushButton_clicked();
+    void on_pushButtonSettingsToThemeSet_clicked();
 
 private:
     Ui::defaultlook *ui;

--- a/tweak/defaultlook.ui
+++ b/tweak/defaultlook.ui
@@ -584,12 +584,13 @@
             </widget>
            </item>
            <item row="6" column="1">
-            <widget class="QPushButton" name="pushButton">
+            <widget class="QPushButton" name="pushButtonSettingsToThemeSet">
              <property name="text">
               <string>Save Current Settings as a Theme Set</string>
              </property>
              <property name="icon">
-              <iconset theme="document-save"/>
+              <iconset theme="document-save">
+               <normaloff>.</normaloff>.</iconset>
              </property>
             </widget>
            </item>

--- a/tweak/defaultlook.ui
+++ b/tweak/defaultlook.ui
@@ -276,7 +276,7 @@
         <enum>QTabWidget::North</enum>
        </property>
        <property name="currentIndex">
-        <number>4</number>
+        <number>1</number>
        </property>
        <widget class="QWidget" name="Panel">
         <attribute name="title">
@@ -580,6 +580,16 @@
             <widget class="QPushButton" name="pushButtonPreview">
              <property name="text">
               <string>Preview</string>
+             </property>
+            </widget>
+           </item>
+           <item row="6" column="1">
+            <widget class="QPushButton" name="pushButton">
+             <property name="text">
+              <string>Save Current Settings as a Theme Set</string>
+             </property>
+             <property name="icon">
+              <iconset theme="document-save"/>
              </property>
             </widget>
            </item>

--- a/tweak/mx-tweak.pro
+++ b/tweak/mx-tweak.pro
@@ -15,15 +15,18 @@ TEMPLATE = app
 SOURCES += main.cpp\
         defaultlook.cpp \
     xfwm_compositor_settings.cpp \
-    window_buttons.cpp
+    window_buttons.cpp \
+    theming_to_tweak.cpp
 
 HEADERS  += defaultlook.h \
     xfwm_compositor_settings.h \
-    window_buttons.h
+    window_buttons.h \
+    theming_to_tweak.h
 
 FORMS    += defaultlook.ui \
     xfwm_compositor_settings.ui \
-    window_buttons.ui
+    window_buttons.ui \
+    theming_to_tweak.ui
 
 TRANSLATIONS += translations/mx-tweak_am.ts \
                 translations/mx-tweak_ar.ts \

--- a/tweak/theming_to_tweak.cpp
+++ b/tweak/theming_to_tweak.cpp
@@ -6,6 +6,11 @@ theming_to_tweak::theming_to_tweak(QWidget *parent) :
     ui(new Ui::theming_to_tweak)
 {
     ui->setupUi(this);
+    connect(ui->lineEdit_Name, &QLineEdit::textChanged, [=](){
+        QString text = ui->lineEdit_Name->text();
+        text.replace('\'', QString());
+        ui->lineEdit_Name->setText(text);
+    });
 }
 
 theming_to_tweak::~theming_to_tweak()

--- a/tweak/theming_to_tweak.cpp
+++ b/tweak/theming_to_tweak.cpp
@@ -1,0 +1,19 @@
+#include "theming_to_tweak.h"
+#include "ui_theming_to_tweak.h"
+
+theming_to_tweak::theming_to_tweak(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::theming_to_tweak)
+{
+    ui->setupUi(this);
+}
+
+theming_to_tweak::~theming_to_tweak()
+{
+    delete ui;
+}
+
+QLineEdit *theming_to_tweak::nameEditor()
+{
+    return ui->lineEdit_Name;
+}

--- a/tweak/theming_to_tweak.h
+++ b/tweak/theming_to_tweak.h
@@ -1,0 +1,24 @@
+#ifndef THEMING_TO_TWEAK_H
+#define THEMING_TO_TWEAK_H
+
+#include <QDialog>
+#include <QLineEdit>
+
+namespace Ui {
+class theming_to_tweak;
+}
+
+class theming_to_tweak : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit theming_to_tweak(QWidget *parent = 0);
+    ~theming_to_tweak();
+
+    QLineEdit* nameEditor();
+private:
+    Ui::theming_to_tweak *ui;
+};
+
+#endif // THEMING_TO_TWEAK_H

--- a/tweak/theming_to_tweak.ui
+++ b/tweak/theming_to_tweak.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>139</height>
+    <height>112</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/tweak/theming_to_tweak.ui
+++ b/tweak/theming_to_tweak.ui
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>theming_to_tweak</class>
+ <widget class="QDialog" name="theming_to_tweak">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>139</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>New Theme Set</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Enter name for new theme set</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="lineEdit_Name"/>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>theming_to_tweak</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>theming_to_tweak</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>


### PR DESCRIPTION
What I Changed
 - I added a button that says: "Save Current Settings as Theme Set"
 - When clicked it displays a dialog asking for a name(single quotes are not allowed because MX Tweak can't handle single quotes
 - When user clicks ok then it grabs the settings via xfconf-query and gets whisker gtk3 theme code from ~/.config/gtk-3.0/whisker-tweak.css